### PR TITLE
Fix missing imports in react projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 -   Update angular projects to use angular 10
 -   Update all PX Blue dependencies to latest versions
 
+### Fixed
+-   Fix missing import statements in new React projects
+
 # v1.0.5
 
 ### Changed

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -48,7 +48,7 @@ export const DEV_DEPENDENCIES = {
 };
 const BASE_LINT_DEPENDENCIES = [
     '@pxblue/eslint-config@^2.0.2',
-    'eslint@^6.6.0',
+    'eslint@^7.0.0',
     'eslint-config-prettier@^6.13.0',
     '@typescript-eslint/eslint-plugin@^4.5.0',
     '@typescript-eslint/parser@^4.5.0',
@@ -179,6 +179,38 @@ export const ROOT_COMPONENT = {
     react:
         '\r\n\t<ThemeProvider theme={createMuiTheme(PXBThemes.blue)}>\r\n\t\t<CssBaseline/>\r\n\t\t<App/>\r\n\t</ThemeProvider>\r\n',
     ionic: '<app-root class="pxb-blue mat-typography mat-app-background"></app-root>',
+    reactNative: '',
+};
+
+export const APP_COMPONENT = {
+    angular: '',
+    react:
+        `import React from 'react';
+        import logo from './logo.svg';
+        import './App.css';
+        
+        
+        const App:React.FC = () => (
+          <div className="App">
+              <header className="App-header">
+                <img src={logo} className="App-logo" alt="logo" />
+                <p>
+                  Edit <code>src/App.tsx</code> and save to reload.
+                </p>
+                <a
+                  className="App-link"
+                  href="https://reactjs.org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn React
+                </a>
+              </header>
+            </div>
+        )
+        
+        export default App;`,
+    ionic: '',
     reactNative: '',
 };
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -184,8 +184,7 @@ export const ROOT_COMPONENT = {
 
 export const APP_COMPONENT = {
     angular: '',
-    react:
-        `import React from 'react';
+    react: `import React from 'react';
         import logo from './logo.svg';
         import './App.css';
         

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -48,7 +48,7 @@ export const DEV_DEPENDENCIES = {
 };
 const BASE_LINT_DEPENDENCIES = [
     '@pxblue/eslint-config@^2.0.2',
-    'eslint@^7.0.0',
+    'eslint@^7.11.0',
     'eslint-config-prettier@^6.13.0',
     '@typescript-eslint/eslint-plugin@^4.5.0',
     '@typescript-eslint/parser@^4.5.0',

--- a/src/extensions/file-extensions.ts
+++ b/src/extensions/file-extensions.ts
@@ -29,7 +29,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
 
         // Install Dependencies
         const spinner = print.spin(`Installing ${description}...`);
-        const command = `${installCommand} ${dependencies.join(' ')}`;
+        const command = `${installCommand} "${dependencies.join('" "')}"`;
 
         const timer = system.startTimer();
         const output = await system.run(command);

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -15,6 +15,7 @@ import {
     PRETTIER_DEPENDENCIES,
     PRETTIER_SCRIPTS,
     PRETTIER_CONFIG,
+    APP_COMPONENT,
 } from '../constants';
 import {
     updateScripts,
@@ -210,9 +211,9 @@ module.exports = (toolbox: GluegunToolbox): void => {
                 config: LINT_CONFIG.tsx,
             });
 
-            let serviceWorker = filesystem.read(`${folder}/src/serviceWorker.ts`);
-            serviceWorker = `/* eslint-disable */\r\n${serviceWorker}`;
-            filesystem.write(`${folder}/src/serviceWorker.ts`, serviceWorker);
+            let webVitals = filesystem.read(`${folder}/src/reportWebVitals.ts`);
+            webVitals = `/* eslint-disable */\r\n${webVitals}`;
+            filesystem.write(`${folder}/src/reportWebVitals.ts`, webVitals);
         }
 
         // Install Code Formatting Packages (optional)
@@ -247,6 +248,13 @@ module.exports = (toolbox: GluegunToolbox): void => {
             .replace('ReactDOM.render(', `${imports}\r\n\r\nReactDOM.render(`)
             .replace('<App />', ROOT_COMPONENT.react);
         filesystem.write(`${folder}/src/index.${!ts ? 'js' : 'tsx'}`, index);
+
+        if (ts && lint) {
+            // update the App.tsx to pass linting
+            let app = filesystem.read(`${folder}/src/App.${!ts ? 'js' : 'tsx'}`, 'utf8');
+            app = APP_COMPONENT.react;
+            filesystem.write(`${folder}/src/App.${!ts ? 'js' : 'tsx'}`, app);
+        }
 
         // Update index.html
         let html = filesystem.read(`${folder}/public/index.html`, 'utf8');
@@ -445,16 +453,16 @@ module.exports = (toolbox: GluegunToolbox): void => {
         printInstructions(
             !expo
                 ? [
-                      `iOS:`,
-                      `• cd ${name}/ios`,
-                      `• pod install`,
-                      `• cd ..`,
-                      `• ${isYarn ? 'yarn' : 'npm run'} ios`,
-                      ``,
-                      `Android:`,
-                      `• Have an Android emulator running`,
-                      `• ${isYarn ? 'yarn' : 'npm run'} android`,
-                  ]
+                    `iOS:`,
+                    `• cd ${name}/ios`,
+                    `• pod install`,
+                    `• cd ..`,
+                    `• ${isYarn ? 'yarn' : 'npm run'} ios`,
+                    ``,
+                    `Android:`,
+                    `• Have an Android emulator running`,
+                    `• ${isYarn ? 'yarn' : 'npm run'} android`,
+                ]
                 : [`cd ${name}`, `${isYarn ? 'yarn' : 'npm'} start`]
         );
         if (!expo)

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -453,16 +453,16 @@ module.exports = (toolbox: GluegunToolbox): void => {
         printInstructions(
             !expo
                 ? [
-                    `iOS:`,
-                    `• cd ${name}/ios`,
-                    `• pod install`,
-                    `• cd ..`,
-                    `• ${isYarn ? 'yarn' : 'npm run'} ios`,
-                    ``,
-                    `Android:`,
-                    `• Have an Android emulator running`,
-                    `• ${isYarn ? 'yarn' : 'npm run'} android`,
-                ]
+                      `iOS:`,
+                      `• cd ${name}/ios`,
+                      `• pod install`,
+                      `• cd ..`,
+                      `• ${isYarn ? 'yarn' : 'npm run'} ios`,
+                      ``,
+                      `Android:`,
+                      `• Have an Android emulator running`,
+                      `• ${isYarn ? 'yarn' : 'npm run'} android`,
+                  ]
                 : [`cd ${name}`, `${isYarn ? 'yarn' : 'npm'} start`]
         );
         if (!expo)

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -244,7 +244,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
         let index = filesystem.read(`${folder}/src/index.${!ts ? 'js' : 'tsx'}`, 'utf8');
         const imports = ROOT_IMPORTS.react.join('\r\n');
         index = `import 'react-app-polyfill/ie11';\r\nimport 'react-app-polyfill/stable';\r\n${index}`
-            .replace("'./serviceWorker';", `'./serviceWorker';\r\n${imports}\r\n`)
+            .replace('ReactDOM.render(', `${imports}\r\n\r\nReactDOM.render(`)
             .replace('<App />', ROOT_COMPONENT.react);
         filesystem.write(`${folder}/src/index.${!ts ? 'js' : 'tsx'}`, index);
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
The latest version of create-react-app no longer adds a line for importing the service worker. We were using this in our find/replace script to add our imports into the index. So projects started with the CLI are missing some required imports in order to run.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- key off of the ReactDom.render line instead of the preceding import line to add our imports
- update app template to pass linting checks
