### PR TITLE
Update commands to work with npx version 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.4.1 (Not published yet)
+
+### Fixed
+
+-   Enable commands to work with npm/npx version 7 by prefixing npx commands with `npm_config_yes=true` (https://omrilotan.medium.com/npx-breaking-on-ci-b9f3f61d4676)
+
 ## v1.4.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "url": "https://github.com/pxblue/pxblue-cli",
         "type": "git"
     },
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "A command-line interface for quickly scaffolding Power Xpert Blue applications",
     "bin": {
         "pxb": "bin/pxb"

--- a/src/constants/code-standards.ts
+++ b/src/constants/code-standards.ts
@@ -1,5 +1,6 @@
 export const LINT_CONFIG = {
     ts: `module.exports =  {
+        root: true,
         parser:  '@typescript-eslint/parser',
         extends:  [ '@pxblue/eslint-config/ts' ],
         parserOptions:  {
@@ -10,6 +11,7 @@ export const LINT_CONFIG = {
         }
     };`,
     tsx: `module.exports =  {
+        root: true,
         parser:  '@typescript-eslint/parser',
         extends:  [ '@pxblue/eslint-config/tsx' ],
         parserOptions:  {

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -123,7 +123,9 @@ module.exports = (toolbox: GluegunToolbox): void => {
                 isTs ? 'expo-template-blank-typescript' : 'blank'
             } "${name}"`;
         } else {
-            command = `npm_config_yes=true npx react-native init ${name} ${isTs ? '--template react-native-template-typescript' : ''}`;
+            command = `npm_config_yes=true npx react-native init ${name} ${
+                isTs ? '--template react-native-template-typescript' : ''
+            }`;
         }
 
         if (cli !== 'expo') {

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -26,7 +26,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
             QUESTIONS.template,
         ]);
 
-        const command = `npx -p @angular/cli@^11.0.0 ng new ${name} --directory "${name}" --style=scss`;
+        const command = `npm_config_yes=true npx -p @angular/cli@^11.0.0 ng new ${name} --directory "${name}" --style=scss`;
         const spinner = print.spin('Creating a new Angular project (this may take a few minutes)...');
         const timer = system.startTimer();
         const output = await system.run(command);
@@ -65,7 +65,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
                 templateName = isTs ? '@pxblue/blank-typescript' : '@pxblue/blank';
         }
 
-        const command = `npx create-react-app ${name} --template ${templateName}`;
+        const command = `npm_config_yes=true create-react-app ${name} --template ${templateName}`;
 
         const spinner = print.spin('Creating a new React project (this may take a few minutes)...');
         const timer = system.startTimer();
@@ -85,7 +85,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
             QUESTIONS.prettier,
         ]);
 
-        const command = `npx ionic start ${name} blank`;
+        const command = `npm_config_yes=true npx ionic start ${name} blank`;
 
         const spinner = print.spin('Creating a new Ionic project (this may take a few minutes)...');
         const timer = system.startTimer();
@@ -119,11 +119,11 @@ module.exports = (toolbox: GluegunToolbox): void => {
 
         let command: string;
         if (cli === 'expo') {
-            command = `npx -p expo-cli expo init --name=${name} --template=${
+            command = `npm_config_yes=true npx -p expo-cli expo init --name=${name} --template=${
                 isTs ? 'expo-template-blank-typescript' : 'blank'
             } "${name}"`;
         } else {
-            command = `npx react-native init ${name} ${isTs ? '--template react-native-template-typescript' : ''}`;
+            command = `npm_config_yes=true npx react-native init ${name} ${isTs ? '--template react-native-template-typescript' : ''}`;
         }
 
         if (cli !== 'expo') {

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -65,7 +65,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
                 templateName = isTs ? '@pxblue/blank-typescript' : '@pxblue/blank';
         }
 
-        const command = `npm_config_yes=true create-react-app ${name} --template ${templateName}`;
+        const command = `npm_config_yes=true npx create-react-app ${name} --template ${templateName}`;
 
         const spinner = print.spin('Creating a new React project (this may take a few minutes)...');
         const timer = system.startTimer();

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -543,7 +543,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
         );
         if (prettier && ts) packageJSON.prettier = '@pxblue/prettier-config';
         packageJSON.scripts.test = 'jest';
-        if (!expo) packageJSON.scripts.rnlink = 'npx react-native link';
+        if (!expo) packageJSON.scripts.rnlink = 'npm_config_yes=true npx react-native link';
         filesystem.write(`${folder}/package.json`, packageJSON, { jsonIndent: 4 });
 
         // Update prettier.rc for JS projects


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
With the latest version (october 2020), npx prompts you (requires user input to confirm) to confirm the installation of the package you are trying to use. Our CLI uses npx commands under the hood, which the user can't respond to and the CLI crashes.

https://omrilotan.medium.com/npx-breaking-on-ci-b9f3f61d4676

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Prefix commands with npm_config_yes=true to eliminate the need to prompt users to install packages with npx
- This is backwards compatible with npx 6 as well.