### PR TITLE
Feature/ionic template

### DIFF
--- a/src/commands/new/ionic.ts
+++ b/src/commands/new/ionic.ts
@@ -6,7 +6,7 @@ module.exports = {
     description: 'Creates a new ionic project',
     run: async (toolbox: GluegunToolbox): Promise<void> => {
         toolbox.fancyPrint.welcomeLogo();
-        const { name, lint, prettier } = await toolbox.createProject.ionic();
-        await toolbox.addPXBlue.ionic({ name, lint, prettier });
+        const { name, lint, prettier, template } = await toolbox.createProject.ionic();
+        await toolbox.addPXBlue.ionic({ name, lint, prettier, template });
     },
 };

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -1,13 +1,6 @@
 export const DEPENDENCIES = {
     ionic: [
-        '@angular/cdk@^10.2.5',
-        '@angular/flex-layout@^10.0.0-beta.32',
-        '@angular/material@^10.2.5',
-        '@pxblue/angular-themes@^6.0.1',
-        '@pxblue/angular-components@^4.0.0',
-        '@pxblue/icons@^1.1.0',
-        '@pxblue/icons-svg@^1.1.1',
-        '@pxblue/colors@^3.0.0',
+        '@angular/animations@^11.0.0'
     ],
     reactNative: [
         '@pxblue/react-native-themes@^5.0.0',
@@ -22,7 +15,6 @@ export const DEPENDENCIES = {
     ],
 };
 export const DEV_DEPENDENCIES = {
-    ionic: [],
     reactNative: ['jest', 'react-test-renderer', '@types/react-native-vector-icons'],
 };
 const BASE_LINT_DEPENDENCIES = [

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -1,7 +1,5 @@
 export const DEPENDENCIES = {
-    ionic: [
-        '@angular/animations@^11.0.0'
-    ],
+    ionic: ['@angular/animations@^11.0.0'],
     reactNative: [
         '@pxblue/react-native-themes@^5.0.0',
         '@pxblue/colors@^3.0.0',

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -2,7 +2,7 @@ export const ROOT_COMPONENT = {
     angular: '<body class="pxb-blue mat-typography mat-app-background">',
     ionic: `
         <body style="display:block" class="pxb-blue mat-typography mat-app-background">
-          <app-root></app-root>
+            <app-root></app-root>
         </body>
     `,
     reactNative: '',

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,8 +1,8 @@
 export const ROOT_COMPONENT = {
     angular: '<body class="pxb-blue mat-typography mat-app-background">',
     ionic: `
-        <body style="display:block">
-          <app-root class="pxb-blue mat-typography mat-app-background"></app-root>
+        <body style="display:block" class="pxb-blue mat-typography mat-app-background">
+          <app-root></app-root>
         </body>
     `,
     reactNative: '',

--- a/src/constants/styles.ts
+++ b/src/constants/styles.ts
@@ -1,6 +1,10 @@
 export const ROOT_COMPONENT = {
     angular: '<body class="pxb-blue mat-typography mat-app-background">',
-    ionic: '<app-root class="pxb-blue mat-typography mat-app-background"></app-root>',
+    ionic: `
+        <body style="display:block">
+          <app-root class="pxb-blue mat-typography mat-app-background"></app-root>
+        </body>
+    `,
     reactNative: '',
 };
 

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -79,10 +79,11 @@ module.exports = (toolbox: GluegunToolbox): void => {
     };
 
     const createIonicProject = async (): Promise<IonicProps> => {
-        const [name, lint, prettier]: [string, boolean, boolean] = await parse([
+        const [name, lint, prettier, template]: [string, boolean, boolean, string] = await parse([
             QUESTIONS.name,
             QUESTIONS.lint,
             QUESTIONS.prettier,
+            QUESTIONS.template,
         ]);
 
         const command = `${NPM7_PREFIX} && npx ionic start ${name} blank`;
@@ -95,7 +96,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
         print.info(output);
         print.success(`Created skeleton Ionic project in ${timer() / 1000} seconds`);
 
-        return { name, lint, prettier };
+        return { name, lint, prettier, template };
     };
 
     const createReactNativeProject = async (): Promise<ReactNativeProps> => {

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -280,6 +280,16 @@ module.exports = (toolbox: GluegunToolbox): void => {
         const { name, lint, prettier, template } = props;
         const folder = `./${name}`;
 
+        // Remove ionic-generated home folder
+        filesystem.remove(`${folder}/src/app/home`);
+
+        // Remove ionic-generated default app.
+        filesystem.remove(`${folder}/src/app/app-routing.module.ts`);
+        filesystem.remove(`${folder}/src/app/app-component.html`);
+        filesystem.remove(`${folder}/src/app/app-component.scss`);
+        filesystem.remove(`${folder}/src/app/app-component.ts`);
+        filesystem.remove(`${folder}/src/app/app-component.spec.ts`);
+
         // Install Dependencies
         await fileModify.installDependencies({
             folder: folder,
@@ -385,12 +395,6 @@ module.exports = (toolbox: GluegunToolbox): void => {
         packageJSON = updateScripts(packageJSON, SCRIPTS.ionic.concat(prettier ? PRETTIER_SCRIPTS.ionic : []));
         if (prettier) packageJSON.prettier = '@pxblue/prettier-config';
         filesystem.write(`${folder}/package.json`, packageJSON, { jsonIndent: 4 });
-
-        // Remove ionic-generated home folder
-        filesystem.remove(`${folder}/src/app/home`);
-
-        // Remove ionic-generated app-routing.module
-        filesystem.remove(`${folder}/src/app/app.routing.module.ts`);
 
         // Update index.html
         let html = filesystem.read(`${folder}/src/index.html`, 'utf8');

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -13,6 +13,7 @@ export type IonicProps = {
     name: string;
     lint: boolean;
     prettier: boolean;
+    template: string;
 };
 export type ReactProps = {
     name: string;


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Generates ionic projects using angular cli templates.


#### Limitations
- These templates do not add IonicModule to the app.module.ts file 
- These templates do not wrap the app with <ion-content> tag.

Our angular templates work in ionic since they don't rely on any ionic-specific components.

I don't think it's necessary to create ionic-specific templates since the angular ones work here, it would be nice to include the <ion-content> wrapper & module, but it would require some find/replace work to be done within the CLI to manually add the missing wrappers.  

An alternative would be to add instructions on how to integrate Ionic components, or just link them out to ionic component docs.  


