### PR TITLE
Remove IE11 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.0 (Unpublished)
+
+### Removed
+
+-   IE11 is no longer supported by Microsoft, we so no longer include the necessary configurations to run projects on that browser.
+
 ## v1.6.0 (April 19, 2021)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "url": "https://github.com/pxblue/pxblue-cli",
         "type": "git"
     },
-    "version": "1.6.0",
+    "version": "1.7.0-beta.0",
     "description": "A command-line interface for quickly scaffolding Power Xpert Blue applications",
     "bin": {
         "pxb": "bin/pxb"

--- a/src/constants/browsers.ts
+++ b/src/constants/browsers.ts
@@ -1,13 +1,7 @@
 export const SUPPORTED_BROWSERS = {
     object: {
-        production: ['>0.2%', 'not dead', 'not op_mini all', 'IE 11', 'not IE 9-10'],
-        development: [
-            'last 1 chrome version',
-            'last 1 firefox version',
-            'last 1 safari version',
-            'ie 11',
-            'not ie 9-10',
-        ],
+        production: ['>0.2%', 'not dead', 'not op_mini all'],
+        development: ['last 1 chrome version', 'last 1 firefox version', 'last 1 safari version'],
     },
-    string: `> 0.5%\r\nlast 2 versions\r\nFirefox ESR\r\nnot dead\r\nIE 11\r\nnot IE 9-10`,
+    string: `> 0.5%\r\nlast 2 versions\r\nFirefox ESR\r\nnot dead`,
 };

--- a/src/constants/scripts.ts
+++ b/src/constants/scripts.ts
@@ -1,5 +1,5 @@
 export const SCRIPTS = {
-    angular: [{ name: 'start', command: 'ng serve --configuration es5' }],
+    angular: [],
     ionic: [],
     reactNative: [],
 };

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -216,14 +216,6 @@ module.exports = (toolbox: GluegunToolbox): void => {
         angularJSON.projects[name].architect.build.options.styles = styles;
         angularJSON.projects[name].architect.test.options.styles = styles;
 
-        // make it work for ie11
-        angularJSON.projects[name].architect.build.configurations['es5'] = { tsConfig: './tsconfig.es5.json' };
-        angularJSON.projects[name].architect.serve.configurations['es5'] = { browserTarget: `${name}:build:es5` };
-        filesystem.write(
-            `${folder}/tsconfig.es5.json`,
-            `{\r\n\t"extends": "./tsconfig.app.json",\r\n\t"compilerOptions": {\r\n\t\t"target": "es5"\r\n\t}\r\n}`
-        );
-
         filesystem.write(`${folder}/angular.json`, angularJSON, { jsonIndent: 4 });
 
         // Update styles.scss


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
For PXBLUE-2029

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update the browserslist to not include IE
- Remove the ES5 configuration / script for Angular

> Another PR is coming that will remove the IE11 polyfills from the react templates (https://github.com/pxblue/react-cli-templates/pull/20)