### PR TITLE
Add start command back for angular

### DIFF
--- a/src/constants/scripts.ts
+++ b/src/constants/scripts.ts
@@ -1,5 +1,5 @@
 export const SCRIPTS = {
-    angular: [],
+    angular: [{ name: 'start', command: 'ng serve --open' }],
     ionic: [],
     reactNative: [],
 };

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -225,7 +225,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
         templateSpinner.stop();
 
         printSuccess(name);
-        printInstructions([`cd ${name}`, `${isYarn ? 'yarn' : 'npm'} start --open`]);
+        printInstructions([`cd ${name}`, `${isYarn ? 'yarn' : 'npm'} start`]);
     };
 
     const addPXBlueReact = async (props: ReactProps): Promise<void> => {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Put the start command back in
    - this was accidentally removed when taking out the ie11 stuff, but our instructions still reference the 'start' command