### PR TITLE
Try to lock down RN version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
--   Use `@react-native-community/cli` v5.0.0 to ensure react native projects are built with v0.64.0 due to compatibility issues between `react-native` v0.65.0 and `react-native-keyboard-aware-scroll-view`.
+-   Use `react-native` v0.64.1 in JS projects due to compatibility issues between `react-native` v0.65.0 and `react-native-keyboard-aware-scroll-view`.
 
 ## v1.8.1 (October 7, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## 1.8.2 (November 1, 2021)
+
+### Changed
+
+-   Use `@react-native-community/cli` v5.0.0 to ensure react native projects are built with v0.64.0 due to compatibility issues between `react-native` v0.65.0 and `react-native-keyboard-aware-scroll-view`.
+
 ## v1.8.1 (October 7, 2021)
 
 ### Changed
 
--   Use `react-native` v0.64.1 due to compatibility issues between `react-native` v0.65.0 and `react-native-keyboard-aware-scroll-view`.
+-   Use `react-native` v0.64.1 in TS projects due to compatibility issues between `react-native` v0.65.0 and `react-native-keyboard-aware-scroll-view`.
 
 ## v1.8.0 (October 1, 2021)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "url": "https://github.com/pxblue/pxblue-cli",
         "type": "git"
     },
-    "version": "1.8.1",
+    "version": "1.8.2",
     "description": "A command-line interface for quickly scaffolding Power Xpert Blue applications",
     "bin": {
         "pxb": "bin/pxb"

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -153,7 +153,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
                 isTs ? 'expo-template-blank-typescript' : 'blank'
             } "${name}"`;
         } else {
-            command = `${NPM7_PREFIX} && npx -p react-native@0.64.0 react-native init ${name} ${
+            command = `${NPM7_PREFIX} && npx -p @react-native-community/cli@5.0.1 react-native init ${name} ${
                 isTs ? '--template react-native-template-typescript@6.6.4' : ''
             }`;
         }

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -153,8 +153,8 @@ module.exports = (toolbox: GluegunToolbox): void => {
                 isTs ? 'expo-template-blank-typescript' : 'blank'
             } "${name}"`;
         } else {
-            command = `${NPM7_PREFIX} && npx -p @react-native-community/cli@5.0.1 react-native init ${name} ${
-                isTs ? '--template react-native-template-typescript@6.6.4' : ''
+            command = `${NPM7_PREFIX} && npx -p react-native@0.64.1 react-native init ${name} ${
+                isTs ? '--template react-native-template-typescript@6.6.4' : '--template react-native@0.64.1'
             }`;
         }
 


### PR DESCRIPTION
Locks down react native to version 64 for all generated projects due to an issue with 65 and the `react-native-keyboard-aware-scroll-view` package.

Original comment:
> Draft PR to try to lock down RN version...
> 
> I'm not super clear on the syntax here but I've tried the current change as well as:
> `${NPM7_PREFIX} && npx -p react-native@5.0.0 react-native init ${name}`
> &&
> `${NPM7_PREFIX} && npx -p react-native@0.64.0 react-native init ${name}`
> This final one seems to work with TS. I haven't found exactly why, but the only difference is the base template that is used from react-native-community. I also didn't test TS for these other commands.
> 
> @joebochill could you take a look at this?
> Some useful links:
> https://github.com/react-native-community/cli#compatibility
> https://github.com/react-native-community/cli/blob/master/docs/commands.md#init